### PR TITLE
cope with package resources declared elsewhere

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -46,14 +46,20 @@ class ipa::client (
     require    => Package[$ipa::client::clntpkg]
   }
 
-  realize Package["$ipa::client::clntpkg"]
+  if ! defined(Package[$ipa::client::clntpkg]) {
+    realize Package["$ipa::client::clntpkg"]
+  }
 
   if $ipa::client::ldaputils {
-    realize Package["$ipa::client::ldaputilspkg"]
+    if ! defined(Package[$ipa::client::ldaputilspkg]) {
+      realize Package["$ipa::client::ldaputilspkg"]
+    }
   }
 
   if $ipa::client::sssdtools {
-    realize Package["$ipa::client::sssdtoolspkg"]
+    if ! defined(Package[$ipa::client::sssdtoolspkg]) {
+      realize Package["$ipa::client::sssdtoolspkg"]
+    }
   }
 
   if $ipa::client::sssd {


### PR DESCRIPTION
This patch should make this code more resilient in the event that various package resources are declared in other manifests.
