### PR TITLE
Add mkhomedir augeas for Debian

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -110,6 +110,19 @@ class ipa::client (
       }
       realize Package['sudo-ldap']
     }
+    
+    if $ipa::client::mkhomedir == true {
+      augeas {
+        'mkhomedir_pam' :
+          context => '/files/etc/pam.d/common-session',
+          changes => ['ins 1000000 after *[last()]',
+                      'set 1000000/type session',
+                      'set 1000000/control required',
+                      'set 1000000/module pam_mkhomedir.so',
+                      'set 1000000/argument umask=0022'],
+          onlyif  => "match *[type='session'][module='pam_mkhomedir.so'][argument='umask=0022'] size == 0"
+      }
+    }
   }
 
   @@ipa::hostadd { "$::fqdn":


### PR DESCRIPTION
RHEL/Centos/Fedora use authconfig to configure pam when --mkhomedir option is selected.
Actually there is a lack of support of --mkhomedir option in Debian/Ubuntu freeipa-client package (there is no authconfig on Debian, it's another mecanism to handle pam update)
That's why it could be usefull to have this functionnality implemented in puppet :)
