### PR TITLE
Rewriting ipa::replicaagreement

### DIFF
--- a/manifests/replicaagreement.pp
+++ b/manifests/replicaagreement.pp
@@ -1,9 +1,9 @@
-define ipa::replicaagreement () {
+define ipa::replicaagreement (
+  $from,
+  $to
+) {
 
-  $from = $name[0]
-  $to   = $name[1]
-
-  exec { "connectreplicas-${host}":
+  exec { "connectreplicas-${from}-${to}":
     command     => "/sbin/runuser -l admin -c \'/usr/sbin/ipa-replica-manage connect --cacert=/etc/ipa/ca.crt ${from} ${to}\'",
     unless      => "/sbin/runuser -l admin -c \'/usr/sbin/ipa-replica-manage list ${from} | /bin/grep ${to} >/dev/null 2>&1\'",
     logoutput   => "on_failure"


### PR DESCRIPTION
Requires a unique $title, takes $from and $to params
