### PR TITLE
Wrap interpolated shell commands in shellquote()

### DIFF
--- a/manifests/clientinstall.pp
+++ b/manifests/clientinstall.pp
@@ -24,8 +24,8 @@ define ipa::clientinstall (
   $dc = prefix([regsubst($domain,'(\.)',',dc=','G')],'dc=')
 
   exec { "client-install-${host}":
-    command   => "/bin/echo | /usr/sbin/ipa-client-install --server=${masterfqdn} --hostname=${host} --domain=${domain} --realm=${realm} --password=${otp} ${mkhomediropt} ${ntpopt} --unattended",
-    unless    => "/bin/bash -c \"LDAPTLS_REQCERT=never /usr/bin/ldapsearch -LLL -x -H ldaps://${masterfqdn} -D uid=admin,cn=users,cn=accounts,${dc} -b ${dc} -w ${adminpw} fqdn=${host} | /bin/grep ^krbPrincipalName\"",
+    command   => shellquote("/bin/echo | /usr/sbin/ipa-client-install --server=${masterfqdn} --hostname=${host} --domain=${domain} --realm=${realm} --password=${otp} ${mkhomediropt} ${ntpopt} --unattended"),
+    unless    => shellquote("/bin/bash -c \"LDAPTLS_REQCERT=never /usr/bin/ldapsearch -LLL -x -H ldaps://${masterfqdn} -D uid=admin,cn=users,cn=accounts,${dc} -b ${dc} -w ${adminpw} fqdn=${host} | /bin/grep ^krbPrincipalName\""),
     timeout   => '0',
     tries     => '60',
     try_sleep => '90',

--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -9,7 +9,7 @@ define ipa::serverinstall (
 ) {
 
   exec { "serverinstall-${host}":
-    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} ${dnsopt} ${ntpopt} --unattended",
+    command   => shellquote("/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} ${dnsopt} ${ntpopt} --unattended"),
     timeout   => '0',
     unless    => "/usr/sbin/ipactl status >/dev/null 2>&1",
     creates   => "/etc/ipa/default.conf",
@@ -32,15 +32,15 @@ define ipa::serverinstall (
     }
 
     exec { "admin_keytab":
-      command => "/usr/sbin/kadmin.local -q 'ktadd -norandkey -k admin.keytab admin' ; /usr/bin/k5start -f ${::ipa_adminhomedir}/admin.keytab -U -o admin -k /tmp/krb5cc_${::ipa_adminuidnumber} > /dev/null 2>&1",
+      command => shellquote("/usr/sbin/kadmin.local -q 'ktadd -norandkey -k admin.keytab admin' ; /usr/bin/k5start -f ${::ipa_adminhomedir}/admin.keytab -U -o admin -k /tmp/krb5cc_${::ipa_adminuidnumber} > /dev/null 2>&1"),
       cwd     => "${::ipa_adminhomedir}",
-      unless  => "/usr/bin/kvno -c /tmp/krb5cc_${::ipa_adminuidnumber} -k ${::ipa_adminhomedir}/admin.keytab admin@${realm}",
+      unless  => shellquote("/usr/bin/kvno -c /tmp/krb5cc_${::ipa_adminuidnumber} -k ${::ipa_adminhomedir}/admin.keytab admin@${realm}"),
       notify  => File["${::ipa_adminhomedir}/admin.keytab"],
       require => Cron["k5start_admin"]
     }
 
     cron { "k5start_admin":
-      command => "/usr/bin/k5start -f ${::ipa_adminhomedir}/admin.keytab -U -o admin -k /tmp/krb5cc_${::ipa_adminuidnumber} > /dev/null 2>&1",
+      command => shellquote("/usr/bin/k5start -f ${::ipa_adminhomedir}/admin.keytab -U -o admin -k /tmp/krb5cc_${::ipa_adminuidnumber} > /dev/null 2>&1"),
       user    => 'root',
       minute  => "*/1",
       require => [Package["kstart"], K5login["${::ipa_adminhomedir}/.k5login"], File["$::ipa_adminhomedir"]]


### PR DESCRIPTION
This strikes me as perhaps a more complete fix for the issue @jrb raises in #24.  However, beware: I have **not** yet tested this code.

Fixes #24
