### PR TITLE
Update loadbalanceconf.pp

### DIFF
--- a/manifests/loadbalanceconf.pp
+++ b/manifests/loadbalanceconf.pp
@@ -7,7 +7,7 @@ define ipa::loadbalanceconf (
 
   $dc = prefix([regsubst($domain,'(\.)',',dc=','G')],'dc=')
 
-  $servers = chop(inline_template('<% @ipaservers.each do |@ipaserver| -%><%= @ipaserver %>,<% end -%>'))
+  $servers = chop(inline_template('<% @ipaservers.each do |ipaserver| -%><%= ipaserver %>,<% end -%>'))
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
puppet 3.3.1 fails with error "(erb):1: formal argument cannot be an instance variable". It works OK when using just ipaserver. Thank you!
