### PR TITLE
[#1] seperate the value forwarderopts and extend the classes in

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -96,10 +96,11 @@ class ipa::master (
     else {
       $forwarderopts = '--no-forwarders'
     }
-    $dnsopt = "--setup-dns ${forwarderopts}"
+    $dnsopt = '--setup-dns'
   }
   else {
     $dnsopt = ''
+    $forwarderopts = ''
   }
 
   $ntpopt = $ipa::master::ntp ? {
@@ -118,6 +119,7 @@ class ipa::master (
     adminpw       => $ipa::master::adminpw,
     dspw          => $ipa::master::dspw,
     dnsopt        => $ipa::master::dnsopt,
+    forwarderopts => $ipa::master::forwarderopts,
     ntpopt        => $ipa::master::ntpopt,
     extcaopt      => $ipa::master::extcaopt,
     require       => Package[$ipa::master::svrpkg]

--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -8,12 +8,13 @@ define ipa::serverinstall (
   $adminpw       = {},
   $dspw          = {},
   $dnsopt        = {},
+  $forwarderopts = {},
   $ntpopt        = {},
   $extcaopt      = {}
 ) {
 
   exec { "serverinstall-${host}":
-    command   => shellquote('/usr/sbin/ipa-server-install',"--hostname=${host}","--realm=${realm}","--domain=${domain}","--admin-password=${adminpw}","--ds-password=${dspw}",$dnsopt,$ntpopt,$extcaopt,'--unattended'),
+    command   => shellquote('/usr/sbin/ipa-server-install',"--hostname=${host}","--realm=${realm}","--domain=${domain}","--admin-password=${adminpw}","--ds-password=${dspw}",$dnsopt,$forwarderopts,$ntpopt,$extcaopt,'--unattended'),
     timeout   => '0',
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',


### PR DESCRIPTION
Hi,

i found some issue if you setup a primary node with a dns setup.
This changes should fix the errors with quotation-marks.

regards

Patrick
