### PR TITLE
change for #1 the line code that use shellqoute.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -91,7 +91,7 @@ class ipa::master (
 
   if $ipa::master::dns {
     if size($ipa::master::forwarders) > 0 {
-      $forwarderopts = join(prefix(shellquote($ipa::master::forwarders), '--forwarder '), ' ')
+      $forwarderopts = join(prefix($ipa::master::forwarders, '--forwarder '), ' ')
     }
     else {
       $forwarderopts = '--no-forwarders'


### PR DESCRIPTION
the qoutation marks are not usefull for the variable forwarders, because you must separate every ip address an than you must validate it. 
In this case the implementation didn't do this.
