### PR TITLE
Service order fixes

### DIFF
--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -13,6 +13,8 @@ define ipa::serverinstall (
   $extcaopt      = {}
 ) {
 
+  anchor { 'ipa::serverinstall::start': }
+
   exec { "serverinstall-${host}":
     command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} $dnsopt $forwarderopts $ntpopt $extcaopt --unattended",
     timeout   => '0',
@@ -23,10 +25,17 @@ define ipa::serverinstall (
   }
 
   ipa::flushcache { "server-${host}":
-    notify => Ipa::Adminconfig[$host],
+    notify  => Ipa::Adminconfig[$host],
+    require => Anchor['ipa::serverinstall::start']
   }
 
   ipa::adminconfig { $host:
-    realm => $realm
+    realm => $realm,
+    require => Anchor['ipa::serverinstall::start']
   }
+
+  anchor { 'ipa::serverinstall::end':
+    require => [Ipa::Flushcache["server-${host}"], Ipa::Adminconfig[$host]]
+  }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,5 +2,12 @@
 #
 # Realizes the IPA service for dependency handling
 class ipa::service {
+  anchor { 'ipa::service::start': }
   realize Service['ipa']
+  anchor { 'ipa::service::end': }
+
+  Anchor['ipa::service::start'] ->
+  Service['ipa'] ->
+  Anchor['ipa::service::end']
+
 }


### PR DESCRIPTION
This module suffers from a lack of anchoring to prevent resource float.  The two fixes below are related to Service[ipa].  The resource was not properly anchored into ipa::server so it's realization was not bound by the requirements of the class.  (ex.  https://github.com/huit/puppet-ipa/blob/master/manifests/master.pp#L151)  Additionally I anchored the defined types in ipa::serverinstall which was my first suspected cause.  It was no until testing that where I realized the realize keyword will cause float.

I found issue similar to above regularly in this module.  I'd like some direction before tackling these.  Anchoring the defined types is easy.  However the realize issue I'd need some input.  Is there a reason packages and services are using realize at all?  If I'm going to do bigger fixes I need some testing help.  My use case for thos module is small and I'll probably change spots I don't use.