### PR TITLE
Fix kinit issues in ipa_replicascheme.rb and hostadd.pp

### DIFF
--- a/lib/facter/ipa_replicascheme.rb
+++ b/lib/facter/ipa_replicascheme.rb
@@ -6,7 +6,7 @@ Facter.add(:ipa_replicascheme, :timeout => 10) do
       if host and domain
         fqdn = [host, domain].join(".")
       end    
-    servers = Facter::Util::Resolution.exec("/sbin/runuser -l admin -c '/usr/sbin/ipa-replica-manage list' 2>/dev/null | /bin/egrep -v '#{fqdn}|winsync' | /bin/cut -d: -f1")
+    servers = Facter::Util::Resolution.exec("/sbin/runuser -l admin -c '/kinit -kt ~admin/admin.keytab admin && klist && usr/sbin/ipa-replica-manage list' 2>/dev/null | /bin/egrep -v '#{fqdn}|winsync' | /bin/cut -d: -f1")
     combinations = servers.scan(/[\w.-]+/).combination(2).to_a
     combinations.collect { |combination| combination.join(',') }.join(':')
     else   

--- a/manifests/hostadd.pp
+++ b/manifests/hostadd.pp
@@ -13,8 +13,8 @@ define ipa::hostadd (
 
   if $::ipa_adminhomedir and is_numeric($::ipa_adminuidnumber) {
     exec { "hostadd-${host}":
-      command   => "/sbin/runuser -l admin -c \'/usr/bin/ipa host-add ${host} --locality=\"${locality}\" --location=\"${location}\" --desc=\"${descinfo}\" --platform=\"${clientpf}\" --os=\"${clientos}\" --password=${otp}\'",
-      unless    => "/sbin/runuser -l admin -c \'/usr/bin/ipa host-show ${host} >/dev/null 2>&1\'",
+      command   => "/sbin/runuser -l admin -c \'kinit -kt /home/admin/admin.keytab admin && /usr/bin/ipa host-add ${host} --locality=\"${locality}\" --location=\"${location}\" --desc=\"${descinfo}\" --platform=\"${clientpf}\" --os=\"${clientos}\" --password=${otp}\'",
+      unless    => "/sbin/runuser -l admin -c \'kinit -kt /home/admin/admin.keytab admin && /usr/bin/ipa host-show ${host} >/dev/null 2>&1\'",
       tries     => '60',
       try_sleep => '60'
     }

--- a/manifests/hostdelete.pp
+++ b/manifests/hostdelete.pp
@@ -3,8 +3,8 @@ define ipa::hostdelete (
 ) {
 
   exec { "hostdelete-${host}":
-    command     => "/sbin/runuser -l admin -c \'/usr/bin/ipa host-del ${host}\'",
+    command     => "kinit -kt /home/admin/admin.keytab admin && /sbin/runuser -l admin -c \'/usr/bin/ipa host-del ${host}\'",
     refreshonly => true,
-    onlyif      => "/sbin/runuser -l admin -c \'/usr/bin/ipa host-show ${host} >/dev/null 2>&1\'"
+    onlyif      => "kinit -kt /home/admin/admin.keytab admin && /sbin/runuser -l admin -c \'/usr/bin/ipa host-show ${host} >/dev/null 2>&1\'"
   }
 }

--- a/templates/sudo-ldap.conf.erb
+++ b/templates/sudo-ldap.conf.erb
@@ -1,4 +1,4 @@
-binddn uid=sudo,cn=sysaccounts,cn=etc,<%= @dc %>
+binddn uid=sudo,cn=sysaccounts,cn=etc,<%= @dc.flatten.join(',') %>
 bindpw <%= @sudopw %>
 
 ssl start_tls
@@ -9,4 +9,4 @@ bind_timelimit 5
 timelimit 15
 
 uri ldap://<%= @masterfqdn %>
-sudoers_base ou=sudoers,<%= @dc %>
+sudoers_base ou=sudoers,<%= @dc.flatten.join(',') %>


### PR DESCRIPTION
Fixes issue #51  as well as 2 other instances where ipa is called without kinit

Should work on any type of system that has the admin keytab.