### PR TITLE
Try to properly escape password strings on serverinstall

### DIFF
--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -19,7 +19,7 @@ define ipa::serverinstall (
   anchor { 'ipa::serverinstall::start': }
 
   exec { "serverinstall-${host}":
-    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} ${dnsopt} ${forwarderopts} ${ntpopt} ${extcaopt} ${idstartopt} --unattended",
+    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password='${adminpw}' --ds-password='${dspw}' ${dnsopt} ${forwarderopts} ${ntpopt} ${extcaopt} ${idstartopt} --unattended",
     timeout   => '0',
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',


### PR DESCRIPTION
Heya,

this simple change just surrounds the password parameters in serverinstall.pp with quotationmarks.
This should be done because users might wanna use complex passwords with spaces or other special symbols in them.