### PR TITLE
Ensure ipa-server-dns is installed

### DIFF
--- a/manifests/cleanup.pp
+++ b/manifests/cleanup.pp
@@ -2,8 +2,9 @@
 #
 # Cleans up an IPA installation
 define ipa::cleanup (
-  $svrpkg  = {},
-  $clntpkg = {}
+  $svrpkg    = {},
+  $svrdnspkg = {},
+  $clntpkg   = {}
 ) {
 
   $pkgrmcmd = $::osfamily ? {
@@ -21,7 +22,7 @@ define ipa::cleanup (
                  if [ -x /usr/sbin/ipa-client-install ]; then /bin/echo | /usr/sbin/ipa-client-install --uninstall --unattended ; fi ;\
                  if [ -x /usr/sbin/ipa-server-install ]; then /usr/sbin/ipa-server-install --uninstall --unattended ; fi ;\
                  if [ -d /var/lib/pki-ca ]; then /usr/bin/pkiremove -pki_instance_root=/var/lib -pki_instance_name=pki-ca -force ; fi ;\
-                 if [ -x ${pkgcmd} ]; then ${pkgrmcmd} ${svrpkg} ${clntpkg} krb5-server 389-ds-base 389-ds-base-libs pki-ca pki-util pki-ca certmonger pki-native-tools pki-symkey pki-setup ipa-pki-common-theme pki-selinux ipa-pki-ca-theme ipa-python ; fi ;\
+                 if [ -x ${pkgcmd} ]; then ${pkgrmcmd} ${svrpkg} ${svrdnspkg} ${clntpkg} krb5-server 389-ds-base 389-ds-base-libs pki-ca pki-util pki-ca certmonger pki-native-tools pki-symkey pki-setup ipa-pki-common-theme pki-selinux ipa-pki-ca-theme ipa-python ; fi ;\
                  if [ -e /etc/openldap/ldap.conf.ipabkp ]; then /bin/cp -f /etc/openldap/ldap.conf.ipabkp /etc/openldap/ldap.conf ; fi ;\
                  if [ -e /etc/krb5.conf.ipabkp ]; then /bin/cp -f /etc/krb5.conf.ipabkp /etc/krb5.conf ; fi ;\
                  if [ -e /etc/krb5.keytab ]; then /bin/mv -f /etc/krb5.keytab /etc/krb5.keytab.puppet-ipa.cleanup ; fi ;\

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -91,10 +91,8 @@ class ipa::client (
 
   if $ipa::client::sssd {
     Ipa::Clientinstall<||> -> Service['sssd']
-    if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease != '12.04') {
-      realize Package['sssd-common']
-    }
-    realize Package['sssd']
+    realize Package['sssd-package']
+    realize Service['sssd']
   }
 
   if $::osfamily == 'Debian' {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -91,7 +91,9 @@ class ipa::client (
 
   if $ipa::client::sssd {
     Ipa::Clientinstall<||> -> Service['sssd']
-    realize Package['sssd-common']
+    if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease != '12.04') {
+      realize Package['sssd-common']
+    }
     realize Service['sssd']
   }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -94,7 +94,7 @@ class ipa::client (
     if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease != '12.04') {
       realize Package['sssd-common']
     }
-    realize Service['sssd']
+    realize Package['sssd']
   }
 
   if $::osfamily == 'Debian' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,13 +162,14 @@ class ipa (
       $sssd_package='sssd-common'
     }
 
-    @package { $sssd_package:
+    @package { 'sssd-package':
+      name   => $sssd_package,
       ensure => present
     }
     @service { 'sssd':
       ensure  => 'running',
       enable  => true,
-      require => Package[$sssd_package],
+      require => Package['sssd-package'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,14 +156,19 @@ class ipa (
   }
 
   if $ipa::sssd {
-    @package { 'sssd-common':
-      ensure => installed
+    if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease == '12.04') {
+      $sssd_package='sssd'
+    } else {
+      $sssd_package='sssd-common'
     }
 
+    @package { $sssd_package:
+      ensure => present
+    }
     @service { 'sssd':
       ensure  => 'running',
       enable  => true,
-      require => Package['sssd-common']
+      require => Package[$sssd_package],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,13 +104,13 @@ class ipa (
   $svrpkg        = 'ipa-server',
   $svrdnspkg     = 'ipa-server-dns',
   $clntpkg       = $::osfamily ? {
-    Debian  => 'freeipa-client',
-    default => 'ipa-client',
+    'Debian' => 'freeipa-client',
+    default  => 'ipa-client',
   },
   $ldaputils     = true,
   $ldaputilspkg  = $::osfamily ? {
-    Debian  => 'ldap-utils',
-    default => 'openldap-clients',
+    'Debian' => 'ldap-utils',
+    default  => 'openldap-clients',
   },
   $idstart       = false
 ) {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -12,6 +12,7 @@
 #
 class ipa::master (
   $svrpkg        = {},
+  $svrdnspkg     = {},
   $dns           = {},
   $forwarders    = [],
   $realm         = {},
@@ -79,8 +80,13 @@ class ipa::master (
   if $::osfamily != 'RedHat' {
     fail("Cannot configure an IPA master server on ${::operatingsystem} operating systems. Must be a RedHat-like operating system.")
   }
+  if $dns == true {
+    $pkglist=[$ipa::master::svrdnspkg,$ipa::master::svrpkg]
+  } else {
+    $pkglist=$ipa::master::svrpkg
+  }
 
-  realize Package[$ipa::master::svrpkg]
+  realize Package[$pkglist]
 
   if $ipa::master::sssd {
     realize Package['sssd-common']
@@ -133,7 +139,7 @@ class ipa::master (
     ntpopt        => $ipa::master::ntpopt,
     extcaopt      => $ipa::master::extcaopt,
     idstart       => $ipa::master::generated_idstart,
-    require       => Package[$ipa::master::svrpkg]
+    require       => Package[$pkglist],
   }
 
   if $extca {


### PR DESCRIPTION
This resolves errors when building from scratch with dns => true:
`DEBUG The ipa-server-install command failed, exception: RuntimeError: Integrated DNS requires 'ipa-server-dns' package`
