### PR TITLE
fix: unquoted fact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,12 +102,12 @@ class ipa (
   $autofs        = false,
   $svrpkg        = 'ipa-server',
   $clntpkg       = $::osfamily ? {
-    Debian  => 'freeipa-client',
+    'Debian'  => 'freeipa-client',
     default => 'ipa-client',
   },
   $ldaputils     = true,
   $ldaputilspkg  = $::osfamily ? {
-    Debian  => 'ldap-utils',
+    'Debian'  => 'ldap-utils',
     default => 'openldap-clients',
   },
   $idstart       = false


### PR DESCRIPTION
 - puppet4 throws following error for unquoted fact values, which is fixed by this update
   Error: Evaluation Error: Resource type not found: Debian at /etc/puppetlabs/code/environments/production/modules/ipa/manifests/init.pp:105:5