### PR TITLE
Make Firewall & hostname optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,8 @@
 #  $clntpkg = 'ipa-client' - IPA client package.
 #  $ldaputils = true - Controls the instalation of the LDAP utilities package.
 #  $ldaputilspkg = 'openldap-clients' - LDAP utilities package.
-#  $enable_firewall = true - Install and Configure iptables 
+#  $enable_firewall = true - Install and Configure iptables ? this is not desired for docker container 
+#  $enable_hostname = true - Configure hostname during instalation? this is not desired for docker container 
 # === Variables
 #
 #
@@ -111,7 +112,8 @@ class ipa (
     default => 'openldap-clients',
   },
   $idstart       = false,
-  $enable_firewall = true
+  $enable_firewall = true,
+  $enable_hostname = true
 ) {
 
   @package { $ipa::svrpkg:
@@ -265,6 +267,7 @@ class ipa (
       selfsign      => $ipa::selfsign,
       idstart       => $ipa::idstart,
       enable_firewall => $ipa::enable_firewall,
+      enable_hostname => $ipa::enable_hostname,
     }
 
     if ! $ipa::adminpw {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,12 +102,12 @@ class ipa (
   $autofs        = false,
   $svrpkg        = 'ipa-server',
   $clntpkg       = $::osfamily ? {
-    Debian  => 'freeipa-client',
+    'Debian'  => 'freeipa-client',
     default => 'ipa-client',
   },
   $ldaputils     = true,
   $ldaputilspkg  = $::osfamily ? {
-    Debian  => 'ldap-utils',
+    'Debian'  => 'ldap-utils',
     default => 'openldap-clients',
   },
   $idstart       = false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,9 @@ class ipa (
   }
 
   if $ipa::dns {
+    @package {'ipa-server-dns':
+      ensure => installed
+    }
     @package { 'bind-dyndb-ldap':
       ensure => installed
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@
 #  $clntpkg = 'ipa-client' - IPA client package.
 #  $ldaputils = true - Controls the instalation of the LDAP utilities package.
 #  $ldaputilspkg = 'openldap-clients' - LDAP utilities package.
-#
+#  $enable_firewall = true - Install and Configure iptables 
 # === Variables
 #
 #
@@ -110,7 +110,8 @@ class ipa (
     'Debian'  => 'ldap-utils',
     default => 'openldap-clients',
   },
-  $idstart       = false
+  $idstart       = false,
+  $enable_firewall = true
 ) {
 
   @package { $ipa::svrpkg:
@@ -259,7 +260,8 @@ class ipa (
       http_pin      => $ipa::http_pin,
       subject       => $ipa::subject,
       selfsign      => $ipa::selfsign,
-      idstart       => $ipa::idstart
+      idstart       => $ipa::idstart,
+      enable_firewall => $ipa::enable_firewall,
     }
 
     if ! $ipa::adminpw {
@@ -278,7 +280,8 @@ class ipa (
       adminpw     => $ipa::adminpw,
       dspw        => $ipa::dspw,
       kstart      => $ipa::kstart,
-      sssd        => $ipa::sssd
+      sssd        => $ipa::sssd,
+      enable_firewall => $ipa::enable_firewall
     }
 
     class { 'ipa::client':

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -39,7 +39,8 @@ class ipa::master (
   $subject       = {},
   $selfsign      = {},
   $idstart       = {},
-  $enable_firewall = ''
+  $enable_firewall = '',
+  $enable_hostname = '',
 ) {
 
   if $enable_firewall {
@@ -111,6 +112,14 @@ class ipa::master (
   else {
     $dnsopt = ''
     $forwarderopts = ''
+  }
+
+  if $ipa::master::enable_hostname {
+    $hostopt = "--hostname=${::fqdn}"
+  }
+  else
+  {
+    $hostopt = ''
   }
 
   $ntpopt = $ipa::master::ntp ? {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -39,7 +39,6 @@ class ipa::master (
   $subject       = {},
   $selfsign      = {},
   $idstart       = {},
-  $hostopt       = {},
   $enable_firewall = '',
   $enable_hostname = '',
 ) {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -39,6 +39,7 @@ class ipa::master (
   $subject       = {},
   $selfsign      = {},
   $idstart       = {},
+  $hostopt       = {},
   $enable_firewall = '',
   $enable_hostname = '',
 ) {
@@ -149,7 +150,8 @@ class ipa::master (
     ntpopt        => $ipa::master::ntpopt,
     extcaopt      => $ipa::master::extcaopt,
     idstart       => $ipa::master::generated_idstart,
-    require       => Package[$ipa::master::svrpkg]
+    require       => Package[$ipa::master::svrpkg],
+    hostopt       => $ipa::master::hostopt
   }
 
   if $extca {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -106,6 +106,7 @@ class ipa::master (
     }
     $dnsopt = '--setup-dns'
     realize Package['bind-dyndb-ldap']
+    realize Package['ipa-server-dns']
   }
   else {
     $dnsopt = ''

--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -11,7 +11,8 @@ define ipa::serverinstall (
   $forwarderopts = {},
   $ntpopt        = {},
   $extcaopt      = {},
-  $idstart       = {}
+  $idstart       = {},
+  $hostopt       = {},
 ) {
 
   $idstartopt = "--idstart=${idstart}"
@@ -19,7 +20,7 @@ define ipa::serverinstall (
   anchor { 'ipa::serverinstall::start': }
 
   exec { "serverinstall-${host}":
-    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password='${adminpw}' --ds-password='${dspw}' ${dnsopt} ${forwarderopts} ${ntpopt} ${extcaopt} ${idstartopt} --unattended",
+    command   => "/usr/sbin/ipa-server-install ${hostopt} --realm=${realm} --domain=${domain} --admin-password='${adminpw}' --ds-password='${dspw}' ${dnsopt} ${forwarderopts} ${ntpopt} ${extcaopt} ${idstartopt} --unattended",
     timeout   => '0',
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',


### PR DESCRIPTION
- It makes firewall configuration optional , useful in docker and for some organizations who do not use host based firewall/iptables

- make hostname option optional , so ipa can be installed in docker container with ease 

- added a ipa-server-dns package which is required dependency to be able to install/configure ipa server with DNS