### PR TITLE
Moving timeout from fact to exec.

### DIFF
--- a/lib/facter/ipa_replicascheme.rb
+++ b/lib/facter/ipa_replicascheme.rb
@@ -1,4 +1,4 @@
-Facter.add(:ipa_replicascheme, :timeout => 10) do
+Facter.add(:ipa_replicascheme) do
   setcode do
     host = Facter.value(:hostname)
     domain = Facter.value(:domain)
@@ -6,7 +6,7 @@ Facter.add(:ipa_replicascheme, :timeout => 10) do
       if host and domain
         fqdn = [host, domain].join(".")
       end    
-    servers = Facter::Util::Resolution.exec("/sbin/runuser -l admin -c '/usr/sbin/ipa-replica-manage list' 2>/dev/null | /bin/egrep -v '#{fqdn}|winsync' | /bin/cut -d: -f1")
+    servers = Facter::Util::Resolution.exec("/sbin/runuser -l admin -c '/usr/sbin/ipa-replica-manage list' 2>/dev/null | /bin/egrep -v '#{fqdn}|winsync' | /bin/cut -d: -f1", :timeout => 10)
     combinations = servers.scan(/[\w.-]+/).combination(2).to_a
     combinations.collect { |combination| combination.join(',') }.join(':')
     else   


### PR DESCRIPTION
Facter no longer supports timeouts on facts and throws a warning. 
https://github.com/huit/puppet-ipa/issues/73